### PR TITLE
Add recipe for compacting half drawers and adjust existing recipe to avoid conflicts

### DIFF
--- a/data/storagedrawers/recipes/compacting_drawers_2.json
+++ b/data/storagedrawers/recipes/compacting_drawers_2.json
@@ -1,0 +1,14 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "#T#",
+        "#T#",
+        "#X#"
+    ],
+    "key": {
+        "#": { "item": "create:iron_sheet" },
+        "T": { "item": "create:mechanical_crafter" },
+        "X": { "tag": "storagedrawers:full_drawers" }
+    },
+    "result": { "item": "storagedrawers:compacting_drawers_2" }
+}

--- a/data/storagedrawers/recipes/compacting_drawers_3.json
+++ b/data/storagedrawers/recipes/compacting_drawers_3.json
@@ -8,7 +8,7 @@
     "key": {
         "#": { "item": "create:iron_sheet" },
         "T": { "item": "create:mechanical_crafter" },
-        "X": { "tag": "storagedrawers:drawers" }
+        "X": { "tag": "storagedrawers:full_drawers" }
     },
     "result": { "item": "storagedrawers:compacting_drawers_3" }
 }

--- a/data/storagedrawers/recipes/compacting_half_drawers_2.json
+++ b/data/storagedrawers/recipes/compacting_half_drawers_2.json
@@ -1,0 +1,14 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "#T#",
+        "#T#",
+        "#X#"
+    ],
+    "key": {
+        "#": { "item": "create:iron_sheet" },
+        "T": { "item": "create:mechanical_crafter" },
+        "X": { "tag": "storagedrawers:half_drawers" }
+    },
+    "result": { "item": "storagedrawers:compacting_half_drawers_2" }
+}

--- a/data/storagedrawers/recipes/compacting_half_drawers_3.json
+++ b/data/storagedrawers/recipes/compacting_half_drawers_3.json
@@ -1,0 +1,14 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "###",
+        "TTT",
+        "#X#"
+    ],
+    "key": {
+        "#": { "item": "create:iron_sheet" },
+        "T": { "item": "create:mechanical_crafter" },
+        "X": { "tag": "storagedrawers:half_drawers" }
+    },
+    "result": { "item": "storagedrawers:compacting_half_drawers_3" }
+}


### PR DESCRIPTION
Thank you for developing this mod/datapack.

## What
- Added a new recipe for compacting half drawers.
- Adjusted the recipe for compacting drawers to avoid conflicts.

## Why
- To support the new types of compacting drawers added in Storage Drawers 12.7.0.

## Additional Notes
- The new recipe for compacting half drawers conflicted with the existing compacting drawers recipe. To avoid this, the recipe for regular compacting drawers was adjusted to use only full-depth drawers.
- The new recipe was added in a way that respects the original recipe. If there are any issues or concerns, please let me know.
- I have not added an image of the new recipe to the README yet.  
  If you would like me to add it, please let me know, or feel free to add it yourself if you prefer.